### PR TITLE
Fix: Resolve undeclared variable in 'if' condition at items:SetAccele…

### DIFF
--- a/2d_Emitter_module.lua
+++ b/2d_Emitter_module.lua
@@ -84,10 +84,8 @@ function System.new(position)
 		end
 	end
 	function items:SetAcceleration(Acceleration:UDim2)
-		if Acceleration then
-			if typeof(options.Acceleration) == "UDim2" then
-				Settings.Acceleration = UDim2.fromOffset(Acceleration.X.Offset,Acceleration.Y.Offset)
-			end
+		if Acceleration and typeof(Acceleration) == "UDim2" then
+			Settings.Acceleration = UDim2.fromOffset(Acceleration.X.Offset,Acceleration.Y.Offset)
 		end
 	end
 	function items:Set(options)
@@ -118,6 +116,9 @@ function System.new(position)
 			if options.Acceleration then
 				if typeof(options.Acceleration) == "UDim2" then
 					Settings.Acceleration = UDim2.fromOffset(options.Acceleration.X.Offset,options.Acceleration.Y.Offset)
+				else
+					Settings.Acceleration = UDim2.fromOffset(0, 0)
+					warn("[2DEmit]: Acceleration must be an UDim2!"
 				end
 			end
 			if options.Texture then


### PR DESCRIPTION
Fixed syntax error in line 88 where 'Acceleration' property was incorrectly checked on an undeclared 'options' object. Now, the parameter passed to 'items:SetAcceleration()' is properly validated to ensure it's a UDim2.